### PR TITLE
fix: add peersCountPerInfoHash in server.get("/stats.json")

### DIFF
--- a/lib/run-uws-tracker.ts
+++ b/lib/run-uws-tracker.ts
@@ -212,9 +212,14 @@ function buildServer(
             debugRequest(server, request);
 
             const swarms = tracker.swarms;
+            const peersCountPerInfoHash: {[key: string]: number} = {};
             let peersCount = 0;
             for (const swarm of swarms.values()) {
                 peersCount += swarm.peers.length;
+                const dump: string = JSON.stringify(swarm);
+                const dict: UnknownObject = JSON.parse(dump) as UnknownObject;
+                const infoHash: string = Buffer.from(dict.infoHash as string, "binary").toString("hex");
+                peersCountPerInfoHash[infoHash] = swarm.peers.length;
             }
 
             const serversStats = new Array<{ server: string; webSocketsCount: number }>();
@@ -233,6 +238,7 @@ function buildServer(
                     peersCount: peersCount,
                     servers: serversStats,
                     memory: process.memoryUsage(),
+                    peersCountPerInfoHash: peersCountPerInfoHash,
                 }));
         },
     ).any(


### PR DESCRIPTION
개인적으로 필요해서 추가한 옵션인데, 통합시킬 필요가 있을까요?
관리하시는 분들 의견은 어떠세요?
수정된 부분은 잘 사용하고 있고 충분히 테스트되었습니다.
좋은 프로젝트 운영해주심 항상 감사드립니다.